### PR TITLE
Allow the next significant release of the FOSJsRoutingBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "symfony/framework-bundle": ">=2.1,<2.4-dev",
-        "friendsofsymfony/jsrouting-bundle": ">=1.0,<1.2",
+        "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0"
     },
     "autoload": {


### PR DESCRIPTION
This will allow for the recent updates, including security update 1.4.0
