### PR TITLE
Add the request to the event, so it can be used for filtering in the eve...

### DIFF
--- a/Controller/CalendarController.php
+++ b/Controller/CalendarController.php
@@ -23,7 +23,7 @@ class CalendarController extends Controller
         $endDatetime = new \DateTime();
         $endDatetime->setTimestamp($request->get('end'));
         
-        $events = $this->container->get('event_dispatcher')->dispatch(CalendarEvent::CONFIGURE, new CalendarEvent($startDatetime, $endDatetime))->getEvents();
+        $events = $this->container->get('event_dispatcher')->dispatch(CalendarEvent::CONFIGURE, new CalendarEvent($startDatetime, $endDatetime, $request))->getEvents();
         
         $response = new \Symfony\Component\HttpFoundation\Response();
         $response->headers->set('Content-Type', 'application/json');

--- a/Event/CalendarEvent.php
+++ b/Event/CalendarEvent.php
@@ -3,6 +3,7 @@
 namespace ADesigns\CalendarBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\HttpFoundation\Request;
 
 use ADesigns\CalendarBundle\Entity\EventEntity;
 
@@ -19,6 +20,8 @@ class CalendarEvent extends Event
     
     private $endDatetime;
     
+    private $request;
+
     private $events;
     
     /**
@@ -27,10 +30,11 @@ class CalendarEvent extends Event
      * @param \DateTime $start Begin datetime to use
      * @param \DateTime $end End datetime to use
      */
-    public function __construct(\DateTime $start, \DateTime $end)
+    public function __construct(\DateTime $start, \DateTime $end, Request $request = null)
     {
         $this->startDatetime = $start;
         $this->endDatetime = $end;
+        $this->request = $request;
         $this->events = new \Doctrine\Common\Collections\ArrayCollection();
     }
 
@@ -64,4 +68,8 @@ class CalendarEvent extends Event
         return $this->endDatetime;
     }
 
+    public function getRequest()
+    {
+        return $this->request;
+    }
 }

--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ class CalendarEventListener
 		$startDate = $calendarEvent->getStartDatetime();
 		$endDate = $calendarEvent->getEndDatetime();
 
+		// The original request so you can get filters from the calendar
+     	$request = $calendarEvent->getRequest();
+        $filter = $request->get('filter');
+
+        // Use the filter in your query for example
+
 		// load events using your custom logic here,
 		// for instance, retrieving events from a repository
 		

--- a/Resources/public/js/calendar-settings.js
+++ b/Resources/public/js/calendar-settings.js
@@ -22,6 +22,10 @@ $(function () {
                     {
                         url: Routing.generate('fullcalendar_loader'), 
 						type: 'POST',
+						// A way to add custom filters to your event listeners
+						data: {
+              			  filter: 'balblabl'
+            			},
                         error: function() {
                            //alert('There was an error while fetching Google Calendar!');
                         }


### PR DESCRIPTION
...ntlisteners

Right now the event listeners can only query on start and enddate. It
can be usefull to have the complete request object available as well, so
it's possible to filter on other variables, like a category selectbox on
the same page.
