### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,9 @@ Before installing, please note that this bundle has a dependency on the [FOSJsRo
 
 Add the following lines in your `composer.json` file:
 
-``` js
-"require": {
-    "adesigns/calendar-bundle": "dev-master"
-}
+```sh
+composer require adesigns/calendar-bundle
 ```
-
-Run Composer to download and install the bundle:
-
-    $ php composer.phar update adesigns/calendar-bundle
 
 Register the bundle in `app/AppKernel.php`:
 


### PR DESCRIPTION
Updated installation instructions via composer to use the `composer require` command without specifying a version.
This is the new recommended way of providing this information and it leads to composer picking the proper version constraint (i.e ~1.2), updating the `composer.json` and running install, all in one command.
