### PR TITLE
Added new fullcalendar git repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ Stylesheet:
 ```    
 Javascript:
 ```
+<script type="text/javascript" src="{{ asset('components/moment/min/moment.min.js') }}"></script>
 <script type="text/javascript" src="{{ asset('components/jquery/jquery.min.js') }}"></script>
-<script type="text/javascript" src="{{ asset('components/fullcalendar/fullcalendar/jquery.fullcalendar.min.js') }}"></script>
+<script type="text/javascript" src="{{ asset('components/fullcalendar/dist/jquery.fullcalendar.min.js') }}"></script>
 <script type="text/javascript" src="{{ asset('bundles/adesignscalendar/js/calendar-settings.js') }}"></script>
 ```    
 Then, in the template where you wish to display the calendar, add the following twig:

--- a/composer.json
+++ b/composer.json
@@ -56,6 +56,27 @@
             "ADesigns\\CalendarBundle": ""
         }
     },
+    "extra": {
+        "component": {
+            "fullcalendar/fullcalendar": {
+                "scripts": [
+                    "dist/fullcalendar.js",
+                    "dist/gcal.js",
+                    "dist/lang-all.js"
+                ],
+                "styles": [
+                    "dist/fullcalendar.css",
+                    "dist/fullcalendar.print.css"
+                ],
+                "files": [
+                    "dist/fullcalendar.min.js",
+                    "dist/fullcalendar.min.css",
+                    "dist/fullcalendar.print.css",
+                    "dist/lang-all.js"
+                ]
+            }
+        }
+    },
     "target-dir": "ADesigns/CalendarBundle",
     "config": {
         "component-dir": "web/components",

--- a/composer.json
+++ b/composer.json
@@ -16,17 +16,17 @@
         {
             "type": "package",
             "package": {
-                "name": "arshaw/fullcalendar",
+                "name": "fullcalendar/fullcalendar",
                 "type": "component",
-                "version": "2.3.2",
+                "version": "2.4.0",
                 "dist": {
                     "type": "zip",
-                    "url": "https://github.com/arshaw/fullcalendar/archive/v2.3.2.zip"
+                    "url": "https://github.com/fullcalendar/fullcalendar/archive/v2.4.0.zip"
                 },
                 "source": {
-                    "url": "https://github.com/arshaw/fullcalendar.git",
+                    "url": "https://github.com/fullcalendar/fullcalendar.git",
                     "type": "git",
-                    "reference": "2.3.2"
+                    "reference": "2.4.0"
                 },
                 "extra": {
                     "component": {
@@ -49,7 +49,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0",
         "components/jquery": ">=1.7.1",
-        "arshaw/fullcalendar": "*"
+        "fullcalendar/fullcalendar": "*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -14,34 +14,8 @@
     ],
     "repositories": [
         {
-            "type": "package",
-            "package": {
-                "name": "fullcalendar/fullcalendar",
-                "type": "component",
-                "version": "2.4.0",
-                "dist": {
-                    "type": "zip",
-                    "url": "https://github.com/fullcalendar/fullcalendar/archive/v2.4.0.zip"
-                },
-                "source": {
-                    "url": "https://github.com/fullcalendar/fullcalendar.git",
-                    "type": "git",
-                    "reference": "2.4.0"
-                },
-                "extra": {
-                    "component": {
-                        "scripts": [
-                            "dist/fullcalendar.min.js"
-                        ],
-                        "styles": [
-                            "dist/fullcalendar.css"
-                        ]
-                    }
-                },
-                "require": {
-                    "robloach/component-installer": "*"
-                }
-            }
+            "type": "vcs",
+            "url": "https://github.com/fullcalendar/fullcalendar"
         }
     ],
     "require": {
@@ -49,6 +23,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0",
         "components/jquery": ">=1.7.1",
+        "robloach/component-installer": "^0.2.3",
         "fullcalendar/fullcalendar": "^2.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0",
         "components/jquery": ">=1.7.1",
-        "fullcalendar/fullcalendar": "*"
+        "fullcalendar/fullcalendar": "^2.4"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0",
         "components/jquery": ">=1.7.1",
-        "fullcalendar/fullcalendar": "^2.4"
+        "fullcalendar/fullcalendar": "^2.4",
+        "moment/moment": "^2.10"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,43 @@
     ],
     "repositories": [
         {
-            "type": "vcs",
-            "url": "https://github.com/fullcalendar/fullcalendar"
+            "type": "package",
+            "package": {
+                "name": "fullcalendar/fullcalendar",
+                "type": "component",
+                "require": {
+                    "robloach/component-installer": "*"
+                },
+                "version": "2.4.0",
+                "dist": {
+                    "type": "zip",
+                    "url": "https://github.com/fullcalendar/fullcalendar/archive/v2.4.0.zip"
+                },
+                "source": {
+                    "url": "https://github.com/fullcalendar/fullcalendar.git",
+                    "type": "git",
+                    "reference": "2.4.0"
+                },
+                "extra": {
+                    "component": {
+                        "scripts": [
+                            "dist/fullcalendar.min.js",
+                            "dist/gcal.js",
+                            "dist/lang-all.js"
+                        ],
+                        "styles": [
+                            "dist/fullcalendar.css",
+                            "dist/fullcalendar.print.css"
+                        ],
+                        "files": [
+                            "dist/fullcalendar.min.js",
+                            "dist/fullcalendar.min.css",
+                            "dist/fullcalendar.print.css",
+                            "dist/lang-all.js"
+                        ]
+                    }
+                }
+            }
         }
     ],
     "require": {
@@ -23,33 +58,11 @@
         "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0",
         "components/jquery": ">=1.7.1",
-        "robloach/component-installer": "^0.2.3",
         "fullcalendar/fullcalendar": "^2.4"
     },
     "autoload": {
         "psr-0": {
             "ADesigns\\CalendarBundle": ""
-        }
-    },
-    "extra": {
-        "component": {
-            "fullcalendar/fullcalendar": {
-                "scripts": [
-                    "dist/fullcalendar.js",
-                    "dist/gcal.js",
-                    "dist/lang-all.js"
-                ],
-                "styles": [
-                    "dist/fullcalendar.css",
-                    "dist/fullcalendar.print.css"
-                ],
-                "files": [
-                    "dist/fullcalendar.min.js",
-                    "dist/fullcalendar.min.css",
-                    "dist/fullcalendar.print.css",
-                    "dist/lang-all.js"
-                ]
-            }
         }
     },
     "target-dir": "ADesigns/CalendarBundle",


### PR DESCRIPTION
Arshaw/fullcalendar is now a redirection of fullcalenda/fullcalendar.
Following https://github.com/fullcalendar/fullcalendar/commit/f37ab30e084a9668b96a9c3b7154e95f0e036376 i have changed the package routing.
I have also updated to 2.4