### PR TITLE
pattern deprecation fix

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://symfony.com/schema/routing http://symfony.com/schema/routing/routing-1.0.xsd">
 
-    <route id="fullcalendar_loader" pattern="/fc-load-events">
+    <route id="fullcalendar_loader" path="/fc-load-events">
         <default key="_controller">ADesignsCalendarBundle:Calendar:loadCalendar</default>
         <option key="expose">true</option>
     </route>

--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,5 +1,5 @@
 fullcalendar_loader:
-    pattern: /fc-load-calendar-events
+    path: /fc-load-calendar-events
     defaults: { _controller: ADesignsCalendarBundle:Calendar:loadCalendar }
     options:
         expose: true


### PR DESCRIPTION
DEPRECATED - The "pattern" option in file "/home/developer/.../adesigns/calendar-bundle/ADesigns/CalendarBundle/Resources/config/routing.xml" is deprecated since version 2.2 and will be removed in 3.0. Use the "path" option in the route definition instead.