### PR TITLE
Remove dependency on FOSJsRouting

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ Once installed, this bundle will use event listeners to load events from any bun
 Installation
 ------------
 
-Before installing, please note that this bundle has a dependency on the [FOSJsRouting](https://github.com/FriendsOfSymfony/FOSJsRoutingBundle) bundle to expose the calendar AJAX event loader route.  Please ensure that the FOSJsRouting bundle is installed and configured before continuing.
-
 ### Through Composer (Symfony 2.1+):
 
 Add the following lines in your `composer.json` file:
@@ -59,6 +57,7 @@ Javascript:
 ```
 <script type="text/javascript" src="{{ asset('bundles/adesignscalendar/js/jquery/jquery-1.8.2.min.js') }}"></script>
 <script type="text/javascript" src="{{ asset('bundles/adesignscalendar/js/fullcalendar/jquery.fullcalendar.min.js') }}"></script>
+<script type="text/javascript">var fcLoaderRoute = "{{ path('fullcalendar_loader') }}";</script>
 <script type="text/javascript" src="{{ asset('bundles/adesignscalendar/js/calendar-settings.js') }}"></script>
 ```    
 Then, in the template where you wish to display the calendar, add the following twig:
@@ -176,7 +175,7 @@ custom filters to your event listeners by adding extra parameters in the eventSo
 ``` javascript
 eventSources: [
         {
-            url: Routing.generate('fullcalendar_loader'),
+            url: fcLoaderRoute,
             type: 'POST',
             // A way to add custom filters to your event listeners
             data: {

--- a/Resources/public/js/calendar-settings.js
+++ b/Resources/public/js/calendar-settings.js
@@ -20,7 +20,7 @@ $(function () {
         },
         eventSources: [
             {
-                url: Routing.generate('fullcalendar_loader'),
+                url: fcLoaderRoute,
                 type: 'POST',
                 // A way to add custom filters to your event listeners
                 data: {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     "require": {
         "symfony/twig-bundle": "~2.1|~3.0",
         "symfony/framework-bundle": "~2.1|~3.0",
-        "friendsofsymfony/jsrouting-bundle": "~1.1",
         "doctrine/collections": ">=1.0"
     },
     "require-dev": {


### PR DESCRIPTION
In my opinion, the dependency on FOSJsRouting is not really necessary and can be avoided with this tiny workaround.

Of course there is a trade-off between those two solutions, but I think the dependency is not worth the little comfort, especially when some people won't even use the .js-file and might embed the javascript directly into the template.